### PR TITLE
Update changelog to mention 22h2 + Copper

### DIFF
--- a/components/ANYSOC/Changelog/changelog.md
+++ b/components/ANYSOC/Changelog/changelog.md
@@ -17,8 +17,8 @@
 | Windows 10 Build 19043 (21h1)                                             | ✅         |
 | Windows 10 Build 19044 (21h2)                                             | ✅         |
 | Windows 11 Build 22000 (21h2)                                             | ✅         |
-| Windows 11 vNext (Nickel Semester)                                        | ✅ *       |
-
+| Windows 11 Build 22621 (22h2)                                             | ✅         |
+| Windows 11 vNext (Copper Semester)                                        | ✅ *       |
 
 * Might break in the future. Long term compatibility uncertain due to ARMv8.1 Atomics being required.
 


### PR DESCRIPTION
Builds 25140 and earlier work fine (only tested 950XL but should be OK for other drivers)