### PR TITLE
Updated readme.md as builds 25169 and later no longer boot.

### DIFF
--- a/components/ANYSOC/Changelog/changelog.md
+++ b/components/ANYSOC/Changelog/changelog.md
@@ -18,10 +18,10 @@
 | Windows 10 Build 19044 (21h2)                                             | ✅         |
 | Windows 11 Build 22000 (21h2)                                             | ✅         |
 | Windows 11 Build 22621 (22h2)                                             | ✅         |
-| Windows 11 vNext (Copper Semester)                                        | ✅ *       |
+| Windows 11 vNext (Copper Semester)                                        | ❌ *      |
 
-* Might break in the future. Long term compatibility uncertain due to ARMv8.1 Atomics being required.
 
+* Builds 25183 and earlier will work fine. Starting with build 25188 ARMv8.1 Atomics are now required.
 
 ❌: Not supported, important issues present
 

--- a/components/ANYSOC/Changelog/changelog.md
+++ b/components/ANYSOC/Changelog/changelog.md
@@ -21,7 +21,7 @@
 | Windows 11 vNext (Copper Semester)                                        | ❌ *       |
 
 
-* Starting with build 25188 ARMv8.1 Atomics are now required. Build 25182 will BSOD on boot. Builds <XXXXX> and earlier will work fine.
+* Starting with build 25188 ARMv8.1 Atomics are now required. Build 25174 to 25183 will BSOD on boot (KMODE_EXCEPTION_NOT_HANDLED). Builds <XXXXX> and earlier will successfully boot.
 
 ❌: Not supported, important issues present
 

--- a/components/ANYSOC/Changelog/changelog.md
+++ b/components/ANYSOC/Changelog/changelog.md
@@ -18,10 +18,10 @@
 | Windows 10 Build 19044 (21h2)                                             | ✅         |
 | Windows 11 Build 22000 (21h2)                                             | ✅         |
 | Windows 11 Build 22621 (22h2)                                             | ✅         |
-| Windows 11 vNext (Copper Semester)                                        | ❌ *      |
+| Windows 11 vNext (Copper Semester)                                        | ❌ *       |
 
 
-* Builds 25183 and earlier will work fine. Starting with build 25188 ARMv8.1 Atomics are now required.
+* Starting with build 25188 ARMv8.1 Atomics are now required. Build 25182 will BSOD on boot. Builds <XXXXX> and earlier will work fine.
 
 ❌: Not supported, important issues present
 

--- a/components/ANYSOC/Changelog/changelog.md
+++ b/components/ANYSOC/Changelog/changelog.md
@@ -21,7 +21,7 @@
 | Windows 11 vNext (Copper Semester)                                        | ❌ *       |
 
 
-* Starting with build 25188 ARMv8.1 Atomics are now required. Build 25174 to 25183 will BSOD on boot (KMODE_EXCEPTION_NOT_HANDLED). Builds <XXXXX> and earlier will successfully boot.
+* Starting with build 25188 ARMv8.1 Atomics are now required. Build 25169 to 25183 will BSOD on boot (KMODE_EXCEPTION_NOT_HANDLED). Builds 25163 and earlier will successfully boot.
 
 ❌: Not supported, important issues present
 


### PR DESCRIPTION
After some testing:
25163 and earlier boot fine on the 950XL 
25169 - 25183 bugcheck upon boot. 
25188 and later require ARMv8.1 Atomics. Have also tested this myself, builds don't make it to the spinner.  [never_released's tweet mentioning build 25188](https://twitter.com/never_released/status/1576852301674778624)